### PR TITLE
Fix JAVADOC for JDK11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,22 +114,23 @@
 					</execution>
 				</executions>
 			</plugin>
-<!--			<plugin>-->
-<!--				<groupId>org.apache.maven.plugins</groupId>-->
-<!--				<artifactId>maven-javadoc-plugin</artifactId>-->
-<!--				<version>2.10.3</version>-->
-<!--				<executions>-->
-<!--					<execution>-->
-<!--						<id>attach-javadocs</id>-->
-<!--						<goals>-->
-<!--							<goal>jar</goal>-->
-<!--						</goals>-->
-<!--						<configuration>-->
-<!--							<excludePackageNames>com.payline.ws.*</excludePackageNames>-->
-<!--						</configuration>-->
-<!--					</execution>-->
-<!--				</executions>-->
-<!--			</plugin>-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.2.0</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<source>8</source>
+							<excludePackageNames>com.payline.ws.*</excludePackageNames>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>jaxws-maven-plugin</artifactId>


### PR DESCRIPTION
maven-javadoc plugin needs more conf to work with JDK 11+