### PR TITLE
Jakarta compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,17 +5,18 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.payline</groupId>
 	<artifactId>payline-java-sdk</artifactId>
-	<version>4.74</version>
+	<version>4.75</version>
 	<name>Payline JAVA SDK Project</name>
 	<description>Modified for TBD using last WSDL from https://docs.monext.fr/display/DT/Endpoints. The Payline API provides access to the various functions of the Payline payment solution. It is based on standard web service components, which include the SOAP protocol, the WSDL and XSD definition languages. These standards are supported by a large range of development tools on multiple platforms. This SDK covers all the functions of the Payline payment solution.</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 		<WebPaymentAPI.service>WebPaymentAPI</WebPaymentAPI.service>
 		<DirectPaymentAPI.service>DirectPaymentAPI</DirectPaymentAPI.service>
 		<ExtendedAPI.service>ExtendedAPI</ExtendedAPI.service>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<jaxws-maven-plugin.version>4.0.1</jaxws-maven-plugin.version>
 	</properties>
 
 	<url>www.payline.com</url>
@@ -137,9 +138,9 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>jaxws-maven-plugin</artifactId>
-				<version>2.6</version>
+                <groupId>com.sun.xml.ws</groupId>
+                <artifactId>jaxws-maven-plugin</artifactId>
+                <version>${jaxws-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>wsimport-from-jdk-extendedapi</id>
@@ -234,29 +235,14 @@
 			<version>1.10</version>
 		</dependency>
 		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-			<version>2.2.11</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-core</artifactId>
-			<version>2.2.11</version>
-		</dependency>
-		<dependency>
 			<groupId>jakarta.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.2.9</version>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.jws</groupId>
-			<artifactId>jsr181-api</artifactId>
-			<version>1.0-MR1</version>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>4.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.xml.ws</groupId>
-			<artifactId>jaxws-api</artifactId>
-			<version>2.2.11</version>
+			<artifactId>jakarta.xml.ws-api</artifactId>
+			<version>4.0.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -244,17 +244,17 @@
 			<version>2.2.11</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.xml.bind</groupId>
+			<groupId>jakarta.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
 			<version>2.2.9</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.jws</groupId>
+			<groupId>jakarta.jws</groupId>
 			<artifactId>jsr181-api</artifactId>
 			<version>1.0-MR1</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.xml.ws</groupId>
+			<groupId>jakarta.xml.ws</groupId>
 			<artifactId>jaxws-api</artifactId>
 			<version>2.2.11</version>
 		</dependency>

--- a/src/main/java/com/payline/kit/utils/Utils.java
+++ b/src/main/java/com/payline/kit/utils/Utils.java
@@ -31,8 +31,8 @@ import java.util.zip.GZIPInputStream;
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.namespace.QName;
-import javax.xml.ws.BindingProvider;
-import javax.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.handler.MessageContext;
 
 import com.payline.ws.model.DirectPaymentAPI;
 import com.payline.ws.model.DirectPaymentAPI_Service;

--- a/src/main/java/com/payline/ws/wrapper/DirectPayment.java
+++ b/src/main/java/com/payline/ws/wrapper/DirectPayment.java
@@ -20,7 +20,7 @@ import com.payline.kit.utils.Utils;
 import com.payline.ws.model.*;
 
 
-import javax.xml.ws.WebServiceException;
+import jakarta.xml.ws.WebServiceException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/src/main/java/com/payline/ws/wrapper/ExtendedAPI.java
+++ b/src/main/java/com/payline/ws/wrapper/ExtendedAPI.java
@@ -18,7 +18,7 @@ package com.payline.ws.wrapper;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.ws.WebServiceException;
+import jakarta.xml.ws.WebServiceException;
 
 import com.payline.ws.model.GetAlertDetailsRequest;
 import com.payline.ws.model.GetAlertDetailsResponse;

--- a/src/main/java/com/payline/ws/wrapper/WalletPayment.java
+++ b/src/main/java/com/payline/ws/wrapper/WalletPayment.java
@@ -18,7 +18,7 @@ package com.payline.ws.wrapper;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.ws.WebServiceException;
+import jakarta.xml.ws.WebServiceException;
 
 import com.payline.ws.model.CreateWalletRequest;
 import com.payline.ws.model.CreateWalletResponse;

--- a/src/main/java/com/payline/ws/wrapper/WebPayment.java
+++ b/src/main/java/com/payline/ws/wrapper/WebPayment.java
@@ -18,7 +18,7 @@ package com.payline.ws.wrapper;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.ws.WebServiceException;
+import jakarta.xml.ws.WebServiceException;
 
 import com.payline.ws.model.DoWebPaymentRequest;
 import com.payline.ws.model.DoWebPaymentResponse;

--- a/src/main/resources/bindings/bind.xml
+++ b/src/main/resources/bindings/bind.xml
@@ -1,9 +1,9 @@
 <jxb:bindings
-	version="2.1"
+	version="3.0"
 	xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
 	xmlns:xs="https://jakarta.ee/xml/ns/jaxb"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-	xmlns:jaxws="http://java.sun.com/xml/ns/jaxws">
+	xmlns:jaxws="https://jakarta.ee/xml/ns/jaxws">
 	<jxb:globalBindings generateElementProperty="false" />
 </jxb:bindings>

--- a/src/main/resources/bindings/bind.xml
+++ b/src/main/resources/bindings/bind.xml
@@ -1,7 +1,7 @@
 <jxb:bindings
 	version="2.1"
-	xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
-	xmlns:xs="http://java.sun.com/xml/ns/jaxb"
+	xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+	xmlns:xs="https://jakarta.ee/xml/ns/jaxb"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
 	xmlns:jaxws="http://java.sun.com/xml/ns/jaxws">


### PR DESCRIPTION
We have adjusted the project dependencies to be compatible with jakarta.
- Deletion of javax dependencies : jaxb-impl, jaxb-core, jaxb-api, jsr181-api, jaxws-api
- Import of jakarta dependencies : jakarta.xml.bind-api, jakarta.xml.ws-api
- The plugin that generates the wsdl was moved to `com.sun.xml.ws/`

This pull request will result in a breaking change that will be incompatible with lower versions.
Perhaps a good approach could be the generation of  an alternative version with a "jakarta" classifier with [maven-deploy](https://maven.apache.org/plugins/maven-deploy-plugin/examples/deploying-with-classifiers.html)